### PR TITLE
Fix typos

### DIFF
--- a/demos/nonlinear/Convergence of the Secant Method.ipynb
+++ b/demos/nonlinear/Convergence of the Secant Method.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Convergence of Newton's Method\n",
+    "# Convergence of the Secant Method\n",
     "\n",
     "Copyright (C) 2020 Andreas Kloeckner\n",
     "\n",
@@ -136,7 +136,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's run Newton's method and keep track of the errors:"
+    "Now let's run the secant method and keep track of the errors:"
    ]
   },
   {


### PR DESCRIPTION
Fixing some typos in the secant method demo.