### PR TITLE
Fix typos in floating point section

### DIFF
--- a/notes/notes.org
+++ b/notes/notes.org
@@ -779,9 +779,9 @@ stored bits in the significand and a (stored) exponent range of \([- 7, 8]\)?
 #+LATEX: \begin{showlater}
 - Can go way smaller using the /special exponent/ (turns off the leading one)
 - Assume that the special exponent is \(- 7\).
-- So: \((0.001)_2 \cdot 2^{-7}\) (with all four digits stored).
+- So: \((0.0001)_2 \cdot 2^{-7}\) (with all four digits stored).
 
-Numbers with the special epxonent are called /subnormal/ (or
+Numbers with the special exponent are called /subnormal/ (or
 /denormal/) FP numbers. Technically, zero is also a
 subnormal.
 #+LATEX: \end{showlater}


### PR DESCRIPTION
- Example is supposed to show smallest possible number in a 5-bit floating point system with 4 stored bits and exponent range [-7, 8]. One of the bits is missing.